### PR TITLE
Nuget Package Creation - v1.9.28

### DIFF
--- a/.github/workflows/publish-nuget-Package.yml
+++ b/.github/workflows/publish-nuget-Package.yml
@@ -1,7 +1,7 @@
 name: Publish Nuget Package
 
 env:
-    NUGET_PACKAGE_NAME_VERSION: "GmailHelper.1.9.27.nupkg"
+    NUGET_PACKAGE_NAME_VERSION: "GmailHelper.1.9.28.nupkg"
 
 on:
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ All notable changes to this project documented here.
 
 ## [Released]
 
-## [1.9.27](https://www.nuget.org/packages/GmailHelper/1.9.27) - 2024-05-4
+## [1.9.28](https://www.nuget.org/packages/GmailHelper/1.9.28) - 2024-05-24
+### Changed
+- MimeKitLite dependency update from ('4.5.0' -> '4.6.0').
+
+## [1.9.27](https://www.nuget.org/packages/GmailHelper/1.9.27) - 2024-05-04
 ### Changed
 - Gmail API dependency update ('1.68.0.3287' -> '1.68.0.3399').
 

--- a/GmailAPIHelper.NET.Tests/GmailAPIHelper.NET.Tests.csproj
+++ b/GmailAPIHelper.NET.Tests/GmailAPIHelper.NET.Tests.csproj
@@ -59,8 +59,8 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.2.8\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="MimeKitLite, Version=4.5.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
-      <HintPath>..\packages\MimeKitLite.4.5.0\lib\netstandard2.0\MimeKitLite.dll</HintPath>
+    <Reference Include="MimeKitLite, Version=4.6.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
+      <HintPath>..\packages\MimeKitLite.4.6.0\lib\netstandard2.0\MimeKitLite.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/GmailAPIHelper.NET.Tests/packages.config
+++ b/GmailAPIHelper.NET.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Google.Apis.Auth" version="1.68.0" targetFramework="net461" />
   <package id="Google.Apis.Core" version="1.68.0" targetFramework="net461" />
   <package id="Google.Apis.Gmail.v1" version="1.68.0.3399" targetFramework="net461" />
-  <package id="MimeKitLite" version="4.5.0" targetFramework="net461" />
+  <package id="MimeKitLite" version="4.6.0" targetFramework="net461" />
   <package id="MSTest.TestAdapter" version="2.2.8" targetFramework="net461" />
   <package id="MSTest.TestFramework" version="2.2.8" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net461" />

--- a/GmailAPIHelper/GmailAPIHelper.csproj
+++ b/GmailAPIHelper/GmailAPIHelper.csproj
@@ -30,8 +30,8 @@ Solution Version:
     <PackageId>GmailHelper</PackageId>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReleaseNotes>1. Gmail API dependency update ('1.68.0.3287' -&gt; '1.68.0.3399').</PackageReleaseNotes>
-    <Version>1.9.27</Version>
+    <PackageReleaseNotes>1. MimeKitLite dependency update from ('4.5.0' -&gt; '4.6.0').</PackageReleaseNotes>
+    <Version>1.9.28</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GmailAPIHelper/GmailAPIHelper.csproj
+++ b/GmailAPIHelper/GmailAPIHelper.csproj
@@ -36,7 +36,7 @@ Solution Version:
 
   <ItemGroup>
     <PackageReference Include="Google.Apis.Gmail.v1" Version="1.68.0.3399" />
-    <PackageReference Include="MimeKitLite" Version="4.5.0" />
+    <PackageReference Include="MimeKitLite" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- MimeKitLite dependency update from ('4.5.0' -> '4.6.0').
- Nuget package creation - v1.9.28.