### PR TITLE
Nuget Package Creation - v1.9.30

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-2019, ubuntu-20.04, macOS-11 ]
+        os: [ windows-2019, ubuntu-20.04, macOS-12 ]
         dotnet-version: [ '3.1.x', '6.0.x' ]
         
     steps:
@@ -113,7 +113,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-2019, ubuntu-20.04, macOS-11 ]
+        os: [ windows-2019, ubuntu-20.04, macOS-12 ]
         dotnet-version: [ '3.1.x' ]
         
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-2019, ubuntu-20.04, macOS-11 ]
+        os: [ windows-2019, ubuntu-20.04, macOS-12 ]
         dotnet-version: [ '3.1.x' ]
         
     steps:

--- a/.github/workflows/publish-nuget-Package.yml
+++ b/.github/workflows/publish-nuget-Package.yml
@@ -1,7 +1,7 @@
 name: Publish Nuget Package
 
 env:
-    NUGET_PACKAGE_NAME_VERSION: "GmailHelper.1.9.29.nupkg"
+    NUGET_PACKAGE_NAME_VERSION: "GmailHelper.1.9.30.nupkg"
 
 on:
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project documented here.
 
 ## [Released]
 
+## [1.9.30](https://www.nuget.org/packages/GmailHelper/1.9.30) - 2024-07-08
+### Changed
+- MimeKitLite dependency update from ('4.6.0' -> '4.7.0').
+
 ## [1.9.29](https://www.nuget.org/packages/GmailHelper/1.9.29) - 2024-05-26
 ### Changed
 - Gmail API dependency update ('1.68.0.3399' -> '1.68.0.3427').

--- a/GmailAPIHelper.NET.Tests/GmailAPIHelper.NET.Tests.csproj
+++ b/GmailAPIHelper.NET.Tests/GmailAPIHelper.NET.Tests.csproj
@@ -59,8 +59,8 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.2.8\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="MimeKitLite, Version=4.6.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
-      <HintPath>..\packages\MimeKitLite.4.6.0\lib\netstandard2.0\MimeKitLite.dll</HintPath>
+    <Reference Include="MimeKitLite, Version=4.7.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
+      <HintPath>..\packages\MimeKitLite.4.7.0\lib\netstandard2.0\MimeKitLite.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/GmailAPIHelper.NET.Tests/packages.config
+++ b/GmailAPIHelper.NET.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Google.Apis.Auth" version="1.68.0" targetFramework="net461" />
   <package id="Google.Apis.Core" version="1.68.0" targetFramework="net461" />
   <package id="Google.Apis.Gmail.v1" version="1.68.0.3427" targetFramework="net461" />
-  <package id="MimeKitLite" version="4.6.0" targetFramework="net461" />
+  <package id="MimeKitLite" version="4.7.0" targetFramework="net461" />
   <package id="MSTest.TestAdapter" version="2.2.8" targetFramework="net461" />
   <package id="MSTest.TestFramework" version="2.2.8" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net461" />

--- a/GmailAPIHelper/GmailAPIHelper.csproj
+++ b/GmailAPIHelper/GmailAPIHelper.csproj
@@ -36,7 +36,7 @@ Solution Version:
 
   <ItemGroup>
     <PackageReference Include="Google.Apis.Gmail.v1" Version="1.68.0.3427" />
-    <PackageReference Include="MimeKitLite" Version="4.6.0" />
+    <PackageReference Include="MimeKitLite" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GmailAPIHelper/GmailAPIHelper.csproj
+++ b/GmailAPIHelper/GmailAPIHelper.csproj
@@ -30,8 +30,8 @@ Solution Version:
     <PackageId>GmailHelper</PackageId>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReleaseNotes>1. Gmail API dependency update ('1.68.0.3399' -&gt; '1.68.0.3427').</PackageReleaseNotes>
-    <Version>1.9.29</Version>
+    <PackageReleaseNotes>1. MimeKitLite dependency update ('4.6.0' -&gt; '4.7.0')</PackageReleaseNotes>
+    <Version>1.9.30</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- MimeKitLite dependency update from ('4.6.0' -> '4.7.0').
- Nuget package creation - v1.9.30.
- GitHub actions update - Mac OS runner version tag update to 12.