### PR TITLE
GitHub Workflows Updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         fetch-depth: 0
     
-    - name: .NET Framework Version [ 4.6.1 ]
+    - name: Install .NET Framework SDK [ Version - 4.6.1 ]
       shell: powershell
       run: |
         choco install netfx-4.6.1-devpack
@@ -83,7 +83,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET Core (MacOS)
+    - name: Install .NET Core SDK (MacOS)
       if: runner.os == 'macOS'
       uses: ./.github/workflows/install-dotnet-core
       with:
@@ -137,7 +137,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET Core (MacOS)
+    - name: Install .NET Core SDK (MacOS)
       if: runner.os == 'macOS'
       uses: ./.github/workflows/install-dotnet-core
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,14 +83,14 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET Core SDK (MacOS)
+    - name: Install .NET Core SDK [ Version - ${{ matrix.dotnet-version }} ] (MacOS)
       if: ${{ runner.os == 'macOS' }}
       uses: ./.github/workflows/install-dotnet-core
       with:
           dotnet-version: ${{ matrix.dotnet-version }}
           architecture: x64
 
-    - name: Dotnet Version (${{ matrix.dotnet-version }})
+    - name: Setup Dotnet [ Version - ${{ matrix.dotnet-version }} ]
       if: ${{ runner.os != 'macOS' }}
       uses: actions/setup-dotnet@v4
       with:
@@ -137,14 +137,14 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET Core SDK (MacOS)
+    - name: Install .NET Core SDK [ Version - ${{ matrix.dotnet-version }} ] (MacOS)
       if: ${{ runner.os == 'macOS' }}
       uses: ./.github/workflows/install-dotnet-core
       with:
           dotnet-version: ${{ matrix.dotnet-version }}
           architecture: x64
 
-    - name: Dotnet Version (${{ matrix.dotnet-version }})
+    - name: Setup Dotnet [ Version - ${{ matrix.dotnet-version }} ]
       if: ${{ runner.os != 'macOS' }}
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
       if: ${{ runner.os == 'macOS' }}
       uses: ./.github/workflows/install-dotnet-core
       with:
-          dotnet-version: 3.1.426
+          dotnet-version: ${{ matrix.dotnet-version }}
           architecture: x64
 
     - name: Dotnet Version (${{ matrix.dotnet-version }})

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,13 +84,14 @@ jobs:
         fetch-depth: 0
 
     - name: Install .NET Core SDK (MacOS)
-      if: ${{ runner.os == 'macOS' && matrix.dotnet-version == '3.1.x' }}
+      if: ${{ runner.os == 'macOS' }}
       uses: ./.github/workflows/install-dotnet-core
       with:
-          dotnet-version: 3.1.426
+          dotnet-version: ${{ matrix.dotnet-version }}
           architecture: x64
 
     - name: Dotnet Version (${{ matrix.dotnet-version }})
+      if: ${{ runner.os != 'macOS' }}
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-2022, ubuntu-22.04, macOS-15 ]
-        dotnet-version: [ '3.1.x', '6.0.x' ]
+        dotnet-version: [ '3.1.x', '6.0.x', '8.0.x', '9.0.x' ]
         
     steps:
     - name: Checkout Repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         fetch-depth: 0
     
-    - name: .NET Framework Version [4.6.1]
+    - name: .NET Framework Version [ 4.6.1 ]
       shell: powershell
       run: |
         choco install netfx-4.6.1-devpack
@@ -83,7 +83,15 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install .NET Core (MacOS)
+      if: runner.os == 'macOS'
+      uses: ./.github/workflows/install-dotnet-core
+      with:
+          dotnet-version: 3.1.426
+          architecture: x64
+
     - name: Dotnet Version (${{ matrix.dotnet-version }})
+      if: runner.os != 'macOS'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
@@ -113,14 +121,14 @@ jobs:
     
     - name: Test
       if: ${{ matrix.dotnet-version == 'N/A' }}
-      run: dotnet test --no-build --verbosity detailed --configuration Release --filter TestCategory=GMAIL-TESTS-DOTNETCORE
+      run: dotnet test --no-build --verbosity normal --configuration Release --filter TestCategory=GMAIL-TESTS-DOTNETCORE
 
   Code-Coverage:
     name: Code Coverage (Codecov)
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-2022, ubuntu-22.04 ]
+        os: [ windows-2022, ubuntu-22.04, macOS-15 ]
         dotnet-version: [ '3.1.x' ]
         
     steps:
@@ -129,7 +137,15 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install .NET Core (MacOS)
+      if: runner.os == 'macOS'
+      uses: ./.github/workflows/install-dotnet-core
+      with:
+          dotnet-version: 3.1.426
+          architecture: x64
+
     - name: Dotnet Version (${{ matrix.dotnet-version }})
+      if: runner.os != 'macOS'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
@@ -159,7 +175,7 @@ jobs:
         
     - name: Test
       if: ${{ matrix.dotnet-version == '3.1.x' }}
-      run: dotnet test --no-build --verbosity detailed --configuration Release --filter TestCategory=GMAIL-TESTS-DOTNETCORE /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
+      run: dotnet test --no-build --verbosity normal --configuration Release --filter TestCategory=GMAIL-TESTS-DOTNETCORE /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
     
     - name: Upload Coverage To Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,14 +84,13 @@ jobs:
         fetch-depth: 0
 
     - name: Install .NET Core SDK (MacOS)
-      if: runner.os == 'macOS'
+      if: ${{ runner.os == 'macOS' && matrix.dotnet-version == '3.1.x' }}
       uses: ./.github/workflows/install-dotnet-core
       with:
           dotnet-version: 3.1.426
           architecture: x64
 
     - name: Dotnet Version (${{ matrix.dotnet-version }})
-      if: runner.os != 'macOS'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
@@ -138,14 +137,14 @@ jobs:
         fetch-depth: 0
 
     - name: Install .NET Core SDK (MacOS)
-      if: runner.os == 'macOS'
+      if: ${{ runner.os == 'macOS' }}
       uses: ./.github/workflows/install-dotnet-core
       with:
           dotnet-version: 3.1.426
           architecture: x64
 
     - name: Dotnet Version (${{ matrix.dotnet-version }})
-      if: runner.os != 'macOS'
+      if: ${{ runner.os != 'macOS' }}
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
@@ -178,6 +177,7 @@ jobs:
       run: dotnet test --no-build --verbosity normal --configuration Release --filter TestCategory=GMAIL-TESTS-DOTNETCORE /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
     
     - name: Upload Coverage To Codecov
+      if: ${{ matrix.dotnet-version == '3.1.x' }}
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-2022, ubuntu-22.04 ]
+        os: [ windows-2022, ubuntu-22.04, macOS-15 ]
         dotnet-version: [ '3.1.x' ]
         
     steps:
@@ -18,7 +18,15 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install .NET Core (MacOS)
+      if: runner.os == 'macOS'
+      uses: ./.github/workflows/install-dotnet-core
+      with:
+          dotnet-version: 3.1.426
+          architecture: x64
+
     - name: Dotnet Version (${{ matrix.dotnet-version }})
+      if: runner.os != 'macOS'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
@@ -48,7 +56,7 @@ jobs:
         
     - name: Test
       if: ${{ matrix.dotnet-version == '3.1.x' }}
-      run: dotnet test --no-build --verbosity detailed --configuration Release --filter TestCategory=GMAIL-TESTS-DOTNETCORE /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
+      run: dotnet test --no-build --verbosity normal --configuration Release --filter TestCategory=GMAIL-TESTS-DOTNETCORE /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
     
     - name: Upload Coverage To Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET Core (MacOS)
+    - name: Install .NET Core SDK (MacOS)
       if: runner.os == 'macOS'
       uses: ./.github/workflows/install-dotnet-core
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,14 +19,14 @@ jobs:
         fetch-depth: 0
 
     - name: Install .NET Core SDK (MacOS)
-      if: runner.os == 'macOS'
+      if: ${{ runner.os == 'macOS' }}
       uses: ./.github/workflows/install-dotnet-core
       with:
           dotnet-version: 3.1.426
           architecture: x64
 
     - name: Dotnet Version (${{ matrix.dotnet-version }})
-      if: runner.os != 'macOS'
+      if: ${{ runner.os != 'macOS' }}
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
@@ -59,6 +59,7 @@ jobs:
       run: dotnet test --no-build --verbosity normal --configuration Release --filter TestCategory=GMAIL-TESTS-DOTNETCORE /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
     
     - name: Upload Coverage To Codecov
+      if: ${{ matrix.dotnet-version == '3.1.x' }}
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,14 +18,14 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET Core SDK (MacOS)
+    - name: Install .NET Core SDK [ Version - ${{ matrix.dotnet-version }} ] (MacOS)
       if: ${{ runner.os == 'macOS' }}
       uses: ./.github/workflows/install-dotnet-core
       with:
-          dotnet-version: 3.1.426
+          dotnet-version: ${{ matrix.dotnet-version }}
           architecture: x64
 
-    - name: Dotnet Version (${{ matrix.dotnet-version }})
+    - name: Setup Dotnet [ Version - ${{ matrix.dotnet-version }} ]
       if: ${{ runner.os != 'macOS' }}
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/install-dotnet-core/action.yml
+++ b/.github/workflows/install-dotnet-core/action.yml
@@ -18,7 +18,6 @@ runs:
         RAW_INPUT: ${{ inputs.dotnet-version }}
       run: |
         DOTNET_CHANNEL="${RAW_INPUT%%.x}"
-        echo "Resolved DOTNET_CHANNEL=$DOTNET_CHANNEL"
 
         RELEASE_INDEX_URL="https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json"
 
@@ -30,7 +29,7 @@ runs:
               | ."releases.json"')
 
         if [ -z "$RELEASES_JSON_URL" ]; then
-        echo "❌ Could not resolve releases.json URL for channel $DOTNET_CHANNEL"
+        echo "Could not resolve releases.json URL for channel $DOTNET_CHANNEL"
         exit 1
         fi
         
@@ -44,7 +43,7 @@ runs:
           | head -n1)
 
         if [ -z "$DOTNET_VERSION" ]; then
-        echo "❌ Could not resolve SDK version from $RELEASES_JSON_URL"
+        echo "Could not resolve SDK version from $RELEASES_JSON_URL"
         exit 1
         fi
         

--- a/.github/workflows/install-dotnet-core/action.yml
+++ b/.github/workflows/install-dotnet-core/action.yml
@@ -15,18 +15,22 @@ runs:
     - name: Resolve .NET Core SDK Version
       shell: bash
       run: |
+        DOTNET_CHANNEL="${{ inputs.dotnet-version }}"
         RELEASE_INDEX_URL="https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json"
 
-        DOTNET_VERSION=$(curl -s $RELEASE_INDEX_URL \
-          | jq -r --arg ver "${{ inputs.dotnet-version }}" '
-            .releasesIndex[]
-            | select(.channel-version == $ver)
-            | .releases.json' \
-          | xargs curl -s \
+        # Get the URL to the channel-specific releases.json
+        RELEASES_JSON_URL=$(curl -s $RELEASE_INDEX_URL \
+          | jq -r --arg ver "$DOTNET_CHANNEL" '
+              .releasesIndex[]
+              | select(.channel-version == $ver)
+              | .releases | .json')
+        
+        # Download and extract latest SDK version
+        DOTNET_VERSION=$(curl -s $RELEASES_JSON_URL \
           | jq -r '
-            .releases[]
-            | select(.sdk.version != null)
-            | .sdk.version' \
+              .releases[]
+              | select(.sdk.version != null)
+              | .sdk.version' \
           | sort -Vr \
           | head -n1)
         

--- a/.github/workflows/install-dotnet-core/action.yml
+++ b/.github/workflows/install-dotnet-core/action.yml
@@ -12,10 +12,29 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve .NET Core SDK Version
+      shell: bash
+      run: |
+        RELEASE_INDEX_URL="https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json"
+
+        DOTNET_VERSION=$(curl -s $RELEASE_INDEX_URL \
+          | jq -r --arg ver "${{ inputs.dotnet-version }}" '
+            .releasesIndex[]
+            | select(.channel-version == $ver)
+            | .releases.json' \
+          | xargs curl -s \
+          | jq -r '
+            .releases[]
+            | select(.sdk.version != null)
+            | .sdk.version' \
+          | sort -Vr \
+          | head -n1)
+        
+        echo "Resolved full SDK version: $DOTNET_VERSION"
+
     - name: Install .NET Core SDK [ ${{ inputs.dotnet-version }} ]
       shell: bash
       run: |
-        DOTNET_VERSION=${{ inputs.dotnet-version }}
         ARCHITECTURE="${{ inputs.architecture }}"
         INSTALL_DIR=$HOME/dotnet
 

--- a/.github/workflows/install-dotnet-core/action.yml
+++ b/.github/workflows/install-dotnet-core/action.yml
@@ -15,7 +15,8 @@ runs:
     - name: Resolve .NET Core SDK Version
       shell: bash
       run: |
-        DOTNET_CHANNEL="${{ inputs.dotnet-version }}"
+        RAW_INPUT="${{ inputs.dotnet-version }}"
+        DOTNET_CHANNEL="${RAW_INPUT%%.x}"
         RELEASE_INDEX_URL="https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json"
 
         # Get the URL to the channel-specific releases.json

--- a/.github/workflows/install-dotnet-core/action.yml
+++ b/.github/workflows/install-dotnet-core/action.yml
@@ -31,7 +31,7 @@ runs:
         DOTNET_VERSION=$(curl -s $RELEASES_JSON_URL \
           | jq -r '
               .releases[]
-              | select(.sdk.version != null)
+              | select(.["sdk.version"] != null)
               | .sdk.version' \
           | sort -Vr \
           | head -n1)

--- a/.github/workflows/install-dotnet-core/action.yml
+++ b/.github/workflows/install-dotnet-core/action.yml
@@ -18,6 +18,8 @@ runs:
         RAW_INPUT: ${{ inputs.dotnet-version }}
       run: |
         DOTNET_CHANNEL="${RAW_INPUT%%.x}"
+        echo "Resolved DOTNET_CHANNEL=$DOTNET_CHANNEL"
+
         RELEASE_INDEX_URL="https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json"
 
         # Get the URL to the channel-specific releases.json
@@ -26,6 +28,11 @@ runs:
               .releasesIndex[]
               | select(.["channel-version"] == $ver)
               | .releases | .json')
+
+        if [ -z "$RELEASES_JSON_URL" ]; then
+        echo "❌ Could not resolve releases.json URL for channel $DOTNET_CHANNEL"
+        exit 1
+        fi
         
         # Download and extract latest SDK version
         DOTNET_VERSION=$(curl -s $RELEASES_JSON_URL \
@@ -35,6 +42,11 @@ runs:
               | .sdk.version' \
           | sort -Vr \
           | head -n1)
+
+        if [ -z "$DOTNET_VERSION" ]; then
+        echo "❌ Could not resolve SDK version from $RELEASES_JSON_URL"
+        exit 1
+        fi
         
         echo "Resolved full SDK version: $DOTNET_VERSION"
         echo "DOTNET_VERSION=$DOTNET_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/install-dotnet-core/action.yml
+++ b/.github/workflows/install-dotnet-core/action.yml
@@ -25,9 +25,9 @@ runs:
         # Get the URL to the channel-specific releases.json
         RELEASES_JSON_URL=$(curl -s $RELEASE_INDEX_URL \
           | jq -r --arg ver "$DOTNET_CHANNEL" '
-              .releasesIndex[]
+              .["releases-index"][]
               | select(.["channel-version"] == $ver)
-              | .releases | .json')
+              | ."releases.json"')
 
         if [ -z "$RELEASES_JSON_URL" ]; then
         echo "❌ Could not resolve releases.json URL for channel $DOTNET_CHANNEL"
@@ -38,7 +38,7 @@ runs:
         DOTNET_VERSION=$(curl -s $RELEASES_JSON_URL \
           | jq -r '
               .releases[]
-              | select(.["sdk.version"] != null)
+              | select(.sdk.version != null)
               | .sdk.version' \
           | sort -Vr \
           | head -n1)

--- a/.github/workflows/install-dotnet-core/action.yml
+++ b/.github/workflows/install-dotnet-core/action.yml
@@ -14,8 +14,9 @@ runs:
   steps:
     - name: Resolve .NET Core SDK Version
       shell: bash
+      env:
+        RAW_INPUT: ${{ inputs.dotnet-version }}
       run: |
-        RAW_INPUT="${{ inputs.dotnet-version }}"
         DOTNET_CHANNEL="${RAW_INPUT%%.x}"
         RELEASE_INDEX_URL="https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json"
 
@@ -36,6 +37,7 @@ runs:
           | head -n1)
         
         echo "Resolved full SDK version: $DOTNET_VERSION"
+        echo "DOTNET_VERSION=$DOTNET_VERSION" >> $GITHUB_ENV
 
     - name: Install .NET Core SDK [ ${{ inputs.dotnet-version }} ]
       shell: bash

--- a/.github/workflows/install-dotnet-core/action.yml
+++ b/.github/workflows/install-dotnet-core/action.yml
@@ -1,0 +1,35 @@
+name: Install .NET Core SDK
+description: Installs a specified .NET Core SDK version
+
+inputs:
+  dotnet-version:
+    description: The version of .NET SDK to install (e.g., 3.1.426)
+    required: true
+  architecture:
+    description: Target architecture (e.g., x64 or arm64)
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install .NET Core SDK [ ${{ inputs.dotnet-version }} ]
+      shell: bash
+      run: |
+        DOTNET_VERSION=${{ inputs.dotnet-version }}
+        ARCHITECTURE="${{ inputs.architecture }}"
+        INSTALL_DIR=$HOME/dotnet
+
+        echo "Installing .NET SDK $DOTNET_VERSION for $ARCHITECTURE..."
+        mkdir -p "$INSTALL_DIR"
+        curl -sSL https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh -o dotnet-install.sh
+        chmod +x dotnet-install.sh
+        ./dotnet-install.sh --version "$DOTNET_VERSION" --install-dir "$INSTALL_DIR" --architecture "$ARCHITECTURE"
+
+    - name: Add dotnet to PATH
+      shell: bash
+      run: echo "$HOME/dotnet" >> $GITHUB_PATH
+
+    - name: Check .NET SDK
+      shell: bash
+      run: |
+        dotnet --info

--- a/.github/workflows/install-dotnet-core/action.yml
+++ b/.github/workflows/install-dotnet-core/action.yml
@@ -24,7 +24,7 @@ runs:
         RELEASES_JSON_URL=$(curl -s $RELEASE_INDEX_URL \
           | jq -r --arg ver "$DOTNET_CHANNEL" '
               .releasesIndex[]
-              | select(.channel-version == $ver)
+              | select(.["channel-version"] == $ver)
               | .releases | .json')
         
         # Download and extract latest SDK version


### PR DESCRIPTION
- Include MacOS for build/test.
- 'Install .NET Core SDK' action template to install .NET Core SDK (x64 / arm64).
- Use 'Install .NET Core SDK' instead of 'Setup Dotnet' action for MacOS (arm64 now by default).