### PR TITLE
Nuget Package Creation - v1.12.4

### DIFF
--- a/.github/workflows/publish-nuget-Package.yml
+++ b/.github/workflows/publish-nuget-Package.yml
@@ -1,7 +1,7 @@
 name: Publish Nuget Package
 
 env:
-    NUGET_PACKAGE_NAME_VERSION: "GmailHelper.1.12.3.nupkg"
+    NUGET_PACKAGE_NAME_VERSION: "GmailHelper.1.12.4.nupkg"
 
 on:
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project documented here.
 
 ## [Released]
 
+## [1.12.4](https://www.nuget.org/packages/GmailHelper/1.12.4) - 2026-06-08
+### Changed
+- MimeKitLite dependency update ('4.15.0' -> '4.15.1').
+
 ## [1.12.3](https://www.nuget.org/packages/GmailHelper/1.12.3) - 2026-05-17
 ### Changed
 - MimeKitLite dependency update ('4.14.0' -> '4.15.0').

--- a/GmailAPIHelper.NET.Tests/GmailAPIHelper.NET.Tests.csproj
+++ b/GmailAPIHelper.NET.Tests/GmailAPIHelper.NET.Tests.csproj
@@ -59,8 +59,8 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.2.8\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="MimeKitLite, Version=4.15.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
-      <HintPath>..\packages\MimeKitLite.4.15.0\lib\netstandard2.0\MimeKitLite.dll</HintPath>
+    <Reference Include="MimeKitLite, Version=4.15.1.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
+      <HintPath>..\packages\MimeKitLite.4.15.1\lib\netstandard2.0\MimeKitLite.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/GmailAPIHelper.NET.Tests/GmailAPIHelper.NET.Tests.csproj
+++ b/GmailAPIHelper.NET.Tests/GmailAPIHelper.NET.Tests.csproj
@@ -59,7 +59,7 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.2.8\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="MimeKitLite, Version=4.15.1.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
+    <Reference Include="MimeKitLite, Version=4.15.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
       <HintPath>..\packages\MimeKitLite.4.15.1\lib\netstandard2.0\MimeKitLite.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/GmailAPIHelper.NET.Tests/packages.config
+++ b/GmailAPIHelper.NET.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Google.Apis.Auth" version="1.73.0" targetFramework="net461" />
   <package id="Google.Apis.Core" version="1.73.0" targetFramework="net461" />
   <package id="Google.Apis.Gmail.v1" version="1.73.0.4029" targetFramework="net461" />
-  <package id="MimeKitLite" version="4.15.0" targetFramework="net461" />
+  <package id="MimeKitLite" version="4.15.1" targetFramework="net461" />
   <package id="MSTest.TestAdapter" version="2.2.8" targetFramework="net461" />
   <package id="MSTest.TestFramework" version="2.2.8" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net461" />

--- a/GmailAPIHelper/GmailAPIHelper.csproj
+++ b/GmailAPIHelper/GmailAPIHelper.csproj
@@ -30,8 +30,8 @@ Solution Version:
     <PackageId>GmailHelper</PackageId>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReleaseNotes>1. MimeKitLite dependency update ('4.14.0' -&gt; '4.15.0').</PackageReleaseNotes>
-    <Version>1.12.3</Version>
+    <PackageReleaseNotes>1. MimeKitLite dependency update ('4.15.0' -&gt; '4.15.1').</PackageReleaseNotes>
+    <Version>1.12.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GmailAPIHelper/GmailAPIHelper.csproj
+++ b/GmailAPIHelper/GmailAPIHelper.csproj
@@ -36,7 +36,7 @@ Solution Version:
 
   <ItemGroup>
     <PackageReference Include="Google.Apis.Gmail.v1" Version="1.73.0.4029" />
-    <PackageReference Include="MimeKitLite" Version="4.15.0" />
+    <PackageReference Include="MimeKitLite" Version="4.15.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Dependency Update
- **MimeKitLite**: 4.15.0 → 4.15.1
- **Project Version**: 1.12.3 → 1.12.4
- Fix package path and update test dependencies manually.

## Changes
- Updated dependency version
- Bumped NuGet package version
- Updated NuGet package release workflow configuration
- Updated CHANGELOG